### PR TITLE
refactor: add support for csproj files using cheerio

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
   },
   "dependencies": {
     "bundle-require": "4.0.2",
+    "cheerio": "1.0.0-rc.12",
     "conventional-changelog": "5.1.0",
     "conventional-changelog-config-spec": "2.1.0",
     "conventional-changelog-conventionalcommits": "7.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ dependencies:
   bundle-require:
     specifier: 4.0.2
     version: 4.0.2(esbuild@0.20.2)
+  cheerio:
+    specifier: 1.0.0-rc.12
+    version: 1.0.0-rc.12
   conventional-changelog:
     specifier: 5.1.0
     version: 5.1.0
@@ -1167,6 +1170,10 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /boolbase@1.0.0:
+    resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+    dev: false
+
   /brace-expansion@1.1.11:
     resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
     dependencies:
@@ -1250,6 +1257,30 @@ packages:
     dependencies:
       get-func-name: 2.0.2
     dev: true
+
+  /cheerio-select@2.1.0:
+    resolution: {integrity: sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==}
+    dependencies:
+      boolbase: 1.0.0
+      css-select: 5.1.0
+      css-what: 6.1.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.1.0
+    dev: false
+
+  /cheerio@1.0.0-rc.12:
+    resolution: {integrity: sha512-VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==}
+    engines: {node: '>= 6'}
+    dependencies:
+      cheerio-select: 2.1.0
+      dom-serializer: 2.0.0
+      domhandler: 5.0.3
+      domutils: 3.1.0
+      htmlparser2: 8.0.2
+      parse5: 7.1.2
+      parse5-htmlparser2-tree-adapter: 7.0.0
+    dev: false
 
   /chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
@@ -1447,6 +1478,21 @@ packages:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  /css-select@5.1.0:
+    resolution: {integrity: sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==}
+    dependencies:
+      boolbase: 1.0.0
+      css-what: 6.1.0
+      domhandler: 5.0.3
+      domutils: 3.1.0
+      nth-check: 2.1.1
+    dev: false
+
+  /css-what@6.1.0:
+    resolution: {integrity: sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==}
+    engines: {node: '>= 6'}
+    dev: false
+
   /dargs@8.1.0:
     resolution: {integrity: sha512-wAV9QHOsNbwnWdNW2FYvE1P56wtgSbM+3SZcdGiWQILwVjACCXDCI3Ai8QlCjMDB8YK5zySiXZYBiwGmNY3lnw==}
     engines: {node: '>=12'}
@@ -1504,6 +1550,33 @@ packages:
       esutils: 2.0.3
     dev: true
 
+  /dom-serializer@2.0.0:
+    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      entities: 4.5.0
+    dev: false
+
+  /domelementtype@2.3.0:
+    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+    dev: false
+
+  /domhandler@5.0.3:
+    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
+    engines: {node: '>= 4'}
+    dependencies:
+      domelementtype: 2.3.0
+    dev: false
+
+  /domutils@3.1.0:
+    resolution: {integrity: sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==}
+    dependencies:
+      dom-serializer: 2.0.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+    dev: false
+
   /dot-prop@5.3.0:
     resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
     engines: {node: '>=8'}
@@ -1527,6 +1600,11 @@ packages:
 
   /emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  /entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+    dev: false
 
   /error-ex@1.3.2:
     resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
@@ -2022,6 +2100,15 @@ packages:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
     dev: true
 
+  /htmlparser2@8.0.2:
+    resolution: {integrity: sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==}
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.1.0
+      entities: 4.5.0
+    dev: false
+
   /human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
@@ -2462,6 +2549,12 @@ packages:
       path-key: 4.0.0
     dev: true
 
+  /nth-check@2.1.1:
+    resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
+    dependencies:
+      boolbase: 1.0.0
+    dev: false
+
   /object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -2569,6 +2662,19 @@ packages:
       json-parse-even-better-errors: 3.0.0
       lines-and-columns: 2.0.3
       type-fest: 3.13.1
+    dev: false
+
+  /parse5-htmlparser2-tree-adapter@7.0.0:
+    resolution: {integrity: sha512-B77tOZrqqfUfnVcOrUvfdLbz4pu4RopLD/4vmu3HUPswwTA8OH0EMW9BlWR2B0RCoiZRAHEUu7IxeP1Pd1UU+g==}
+    dependencies:
+      domhandler: 5.0.3
+      parse5: 7.1.2
+    dev: false
+
+  /parse5@7.1.2:
+    resolution: {integrity: sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==}
+    dependencies:
+      entities: 4.5.0
     dev: false
 
   /path-exists@3.0.0:

--- a/src/strategies/__tests__/csharp-project.test.ts
+++ b/src/strategies/__tests__/csharp-project.test.ts
@@ -1,0 +1,140 @@
+import { readFileSync } from "node:fs";
+import { createTestDir } from "../../../tests/create-test-directory";
+import { CSharpProject } from "../csharp-project";
+
+describe("strategies csproj-package", () => {
+	it("should read version from csproj file", async () => {
+		const { config, logger, createFile } = await createTestDir("strategies csproj-package");
+		const fileManager = new CSharpProject(config, logger);
+
+		createFile(
+			`<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<Version>1.2.3</Version>
+	</PropertyGroup>
+</Project>
+`,
+			"API.csproj",
+		);
+
+		const file = fileManager.read("API.csproj");
+		expect(file?.version).toEqual("1.2.3");
+	});
+
+	it("should log a message if unable to read version", async () => {
+		const { config, logger, createFile } = await createTestDir("strategies csproj-package");
+		const fileManager = new CSharpProject(config, logger);
+
+		createFile(
+			`<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<Version></Version>
+	</PropertyGroup>
+</Project>
+`,
+			"API.csproj",
+		);
+
+		const file = fileManager.read("API.csproj");
+		expect(file).toBeUndefined();
+		expect(logger.warn).toBeCalledWith(
+			"[File Manager] Unable to determine csproj package: API.csproj",
+		);
+	});
+
+	it("should write a csproj file", async () => {
+		const { relativeTo, config, logger, createFile } = await createTestDir(
+			"strategies csproj-package",
+		);
+		const fileManager = new CSharpProject(config, logger);
+
+		createFile(
+			`<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<Version>1.2.3</Version>
+	</PropertyGroup>
+</Project>
+`,
+			"API.csproj",
+		);
+
+		fileManager.write(
+			{
+				name: "API.csproj",
+				path: relativeTo("API.csproj"),
+				version: "1.2.3",
+			},
+			"4.5.6",
+		);
+
+		const file = fileManager.read(relativeTo("API.csproj"));
+		expect(file?.version).toEqual("4.5.6");
+	});
+
+	it("should keep the same property ordering", async () => {
+		const { relativeTo, config, logger, createFile } = await createTestDir(
+			"strategies csproj-package",
+		);
+		const fileManager = new CSharpProject(config, logger);
+
+		createFile(
+			`<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<OutputType>Library</OutputType>
+		<TargetFramework>net7.0-windows</TargetFramework>
+		<Version>1.2.3</Version>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Data.Sqlite" Version="7.0.5" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.5" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="7.0.5">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+	</ItemGroup>
+
+</Project>
+`,
+			"API.csproj",
+		);
+
+		fileManager.write(
+			{
+				name: "API.csproj",
+				path: relativeTo("API.csproj"),
+				version: "1.2.3",
+			},
+			"4.5.6",
+		);
+
+		const updatedFileContent = readFileSync(relativeTo("API.csproj"), "utf8");
+
+		expect(updatedFileContent).toEqual(
+			`<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<OutputType>Library</OutputType>
+		<TargetFramework>net7.0-windows</TargetFramework>
+		<Version>4.5.6</Version>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Data.Sqlite" Version="7.0.5" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.5" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="7.0.5">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+	</ItemGroup>
+
+</Project>
+`,
+		);
+	});
+});

--- a/src/strategies/__tests__/file-manager.test.ts
+++ b/src/strategies/__tests__/file-manager.test.ts
@@ -24,6 +24,24 @@ describe("strategies file-manager", () => {
 		expect(file?.version).toEqual("1.2.3");
 	});
 
+	it("should read csproj when file extension is csproj", async () => {
+		const { config, logger, createFile } = await createTestDir("strategies csproj-package");
+		const fileManager = new FileManager(config, logger);
+
+		createFile(
+			`<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<Version>1.2.3</Version>
+	</PropertyGroup>
+</Project>
+`,
+			"API.csproj",
+		);
+
+		const file = fileManager.read("API.csproj");
+		expect(file?.version).toEqual("1.2.3");
+	});
+
 	it("should log an error when read file type is not supported", async () => {
 		const { config, logger, createFile } = await createTestDir("strategies file-manager");
 		const fileManager = new FileManager(config, logger);
@@ -85,6 +103,35 @@ describe("strategies file-manager", () => {
 		);
 		const version = readFileSync(relativeTo("version.txt"), "utf-8");
 		expect(version).toEqual("1.2.3");
+	});
+
+	it("should write csproj when file extension is csproj", async () => {
+		const { relativeTo, config, logger, createFile } = await createTestDir(
+			"strategies csproj-package",
+		);
+		const fileManager = new FileManager(config, logger);
+
+		createFile(
+			`<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<Version>1.2.3</Version>
+	</PropertyGroup>
+</Project>
+`,
+			"API.csproj",
+		);
+
+		fileManager.write(
+			{
+				name: "API.csproj",
+				path: relativeTo("API.csproj"),
+				version: "1.2.3",
+			},
+			"4.5.6",
+		);
+
+		const file = fileManager.read(relativeTo("API.csproj"));
+		expect(file?.version).toEqual("4.5.6");
 	});
 
 	it("should log an error when write file type is not supported", async () => {

--- a/src/strategies/csharp-project.ts
+++ b/src/strategies/csharp-project.ts
@@ -1,0 +1,60 @@
+import { resolve } from "node:path";
+import { readFileSync, writeFileSync } from "node:fs";
+import * as cheerio from "cheerio/lib/slim";
+
+import { fileExists } from "../utils/file-state";
+import type { ForkConfig } from "../config/schema";
+import type { Logger } from "../utils/logger";
+import type { FileState, IFileManager } from "./file-manager";
+
+/**
+ * A csproj file is an xml file with a version property under the Project > PropertyGroup node.
+ *
+ * @example
+ * ```xml
+ * <Project Sdk="Microsoft.NET.Sdk">
+ *   <PropertyGroup>
+ *     <Version>1.2.3</Version>
+ *   </PropertyGroup>
+ * </Project>
+ * ```
+ */
+export class CSharpProject implements IFileManager {
+	constructor(
+		private config: ForkConfig,
+		private logger: Logger,
+	) {}
+
+	public read(fileName: string): FileState | undefined {
+		const filePath = resolve(this.config.path, fileName);
+
+		if (fileExists(filePath)) {
+			const fileContents = readFileSync(filePath, "utf8");
+			const $ = cheerio.load(fileContents, { xmlMode: true });
+
+			const version = $("Project > PropertyGroup > Version").text();
+			if (version) {
+				return {
+					name: fileName,
+					path: filePath,
+					version: version,
+				};
+			}
+
+			this.logger.warn(`[File Manager] Unable to determine csproj package: ${fileName}`);
+		}
+	}
+
+	public write(fileState: FileState, newVersion: string) {
+		const fileContents = readFileSync(fileState.path, "utf8");
+		const $ = cheerio.load(fileContents, { xmlMode: true });
+
+		$("Project > PropertyGroup > Version").text(newVersion);
+
+		// Cheerio doesn't handle self-closing tags well,
+		// so we're manually adding a space before the closing tag.
+		const updatedContent = $.xml().replaceAll('"/>', '" />');
+
+		writeFileSync(fileState.path, updatedContent, "utf8");
+	}
+}

--- a/src/strategies/file-manager.ts
+++ b/src/strategies/file-manager.ts
@@ -1,5 +1,6 @@
 import { JSONPackage } from "./json-package";
 import { PlainText } from "./plain-text";
+import { CSharpProject } from "./csharp-project";
 
 import type { ForkConfig } from "../config/schema";
 import type { Logger } from "../utils/logger";
@@ -20,6 +21,7 @@ export interface IFileManager {
 export class FileManager implements IFileManager {
 	private JSONPackage: JSONPackage;
 	private PlainText: PlainText;
+	private CSharpProject: CSharpProject;
 
 	constructor(
 		private config: ForkConfig,
@@ -27,6 +29,7 @@ export class FileManager implements IFileManager {
 	) {
 		this.JSONPackage = new JSONPackage(config, logger);
 		this.PlainText = new PlainText(config, logger);
+		this.CSharpProject = new CSharpProject(config, logger);
 	}
 
 	/**
@@ -51,6 +54,10 @@ export class FileManager implements IFileManager {
 
 		if (_fileName.endsWith("version.txt")) {
 			return this.PlainText.read(fileName);
+		}
+
+		if (_fileName.endsWith(".csproj")) {
+			return this.CSharpProject.read(fileName);
 		}
 
 		this.logger.error(`[File Manager] Unsupported file: ${fileName}`);
@@ -79,6 +86,10 @@ export class FileManager implements IFileManager {
 
 		if (_fileName.endsWith("version.txt")) {
 			return this.PlainText.write(fileState, newVersion);
+		}
+
+		if (_fileName.endsWith(".csproj")) {
+			return this.CSharpProject.write(fileState, newVersion);
 		}
 
 		this.logger.error(`[File Manager] Unsupported file: ${fileState.path}`);


### PR DESCRIPTION
Adds support for reading and writing c# project files of which the content is xml.
Closes #36 for now until I have more examples of xml to support.