### PR TITLE
refactor: extract types from schema + use js file to define schema

### DIFF
--- a/fork.config.js
+++ b/fork.config.js
@@ -1,4 +1,4 @@
-import { defineConfig } from "./src/config/schema";
+import { defineConfig } from "./src/config/user-config";
 
 export default defineConfig({
 	header: "# Fork Version\n",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "name": "Eanna Glavin",
     "url": "https://eglavin.com"
   },
-  "packageManager": "pnpm@8.15.6",
+  "packageManager": "pnpm@8.15.9",
   "private": false,
   "type": "module",
   "main": "dist/index.cjs",

--- a/scripts/generate-json-schema.js
+++ b/scripts/generate-json-schema.js
@@ -5,7 +5,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { readFileSync, writeFileSync } from "node:fs";
 import { zodToJsonSchema } from "zod-to-json-schema";
-import { ForkConfigSchema } from "../dist/index.js";
+import { ForkConfigSchema } from "../src/config/schema.js";
 
 const projectRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
 const { name, version } = JSON.parse(readFileSync(join(projectRoot, "package.json"), "utf-8"));

--- a/src/config/__tests__/user-config.test.ts
+++ b/src/config/__tests__/user-config.test.ts
@@ -1,6 +1,6 @@
-import { defineConfig } from "../schema";
+import { defineConfig } from "../user-config";
 
-describe("schema", () => {
+describe("user-config", () => {
 	it("should return the given config", () => {
 		const config = defineConfig({ changelog: "MY_CHANGELOG.md" });
 

--- a/src/config/changelog-preset-config.ts
+++ b/src/config/changelog-preset-config.ts
@@ -1,11 +1,8 @@
 import { z } from "zod";
 import conventionalChangelogConfigSpec from "conventional-changelog-config-spec";
 
-import {
-	ChangelogPresetConfigTypeSchema,
-	ChangelogPresetConfigSchema,
-	type ForkConfig,
-} from "./schema";
+import { ChangelogPresetConfigTypeSchema, ChangelogPresetConfigSchema } from "./schema";
+import type { ForkConfig } from "./types";
 import type { getCliArguments } from "./cli-arguments";
 import type { DetectedGitHost } from "./detect-git-host";
 

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -1,4 +1,4 @@
-import type { ForkConfig } from "./schema";
+import type { ForkConfig } from "./types";
 
 export const DEFAULT_CONFIG: ForkConfig = {
 	// Commands

--- a/src/config/schema.js
+++ b/src/config/schema.js
@@ -285,11 +285,3 @@ export const ForkConfigSchema = z.object({
 		.optional()
 		.describe("Add a suffix to the release commit message."),
 });
-
-export type ForkConfig = z.infer<typeof ForkConfigSchema>;
-
-export type Config = Partial<ForkConfig>;
-
-export function defineConfig(config: Config): Config {
-	return config;
-}

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -1,0 +1,6 @@
+import type { z } from "zod";
+import type { ForkConfigSchema } from "./schema";
+
+export type ForkConfig = z.infer<typeof ForkConfigSchema>;
+
+export type Config = Partial<ForkConfig>;

--- a/src/config/user-config.ts
+++ b/src/config/user-config.ts
@@ -4,11 +4,12 @@ import JoyCon from "joycon";
 import { bundleRequire } from "bundle-require";
 import { glob } from "glob";
 
-import { ForkConfigSchema, type ForkConfig } from "./schema";
+import { ForkConfigSchema } from "./schema";
 import { DEFAULT_CONFIG } from "./defaults";
 import { getCliArguments } from "./cli-arguments";
 import { getChangelogPresetConfig } from "./changelog-preset-config";
 import { detectGitHost } from "./detect-git-host";
+import type { Config, ForkConfig } from "./types";
 
 /**
  * Name of the key in the package.json file that contains the users configuration.
@@ -137,4 +138,8 @@ function getFilesList(
 	}
 
 	return DEFAULT_CONFIG.files;
+}
+
+export function defineConfig(config: Config): Config {
+	return config;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
-export { ForkConfigSchema, type ForkConfig, type Config, defineConfig } from "./config/schema";
-export { getUserConfig } from "./config/user-config";
+export { ForkConfigSchema } from "./config/schema";
+export type { ForkConfig, Config } from "./config/types";
+export { getUserConfig, defineConfig } from "./config/user-config";
 
 export {
 	getCurrentVersion,

--- a/src/process/changelog.ts
+++ b/src/process/changelog.ts
@@ -3,7 +3,7 @@ import { writeFileSync, readFileSync } from "node:fs";
 import conventionalChangelog from "conventional-changelog";
 
 import { fileExists } from "../utils/file-state";
-import type { ForkConfig } from "../config/schema";
+import type { ForkConfig } from "../config/types";
 import type { Logger } from "../utils/logger";
 
 /**

--- a/src/process/commit.ts
+++ b/src/process/commit.ts
@@ -1,7 +1,7 @@
 import { resolve } from "node:path";
 import { formatCommitMessage } from "../utils/format-commit-message";
 import { fileExists } from "../utils/file-state";
-import type { ForkConfig } from "../config/schema";
+import type { ForkConfig } from "../config/types";
 import type { FileState } from "../strategies/file-manager";
 import type { Logger } from "../utils/logger";
 import type { Git } from "../utils/git";

--- a/src/process/tag.ts
+++ b/src/process/tag.ts
@@ -1,5 +1,5 @@
 import { formatCommitMessage } from "../utils/format-commit-message";
-import type { ForkConfig } from "../config/schema";
+import type { ForkConfig } from "../config/types";
 import type { Logger } from "../utils/logger";
 import type { Git } from "../utils/git";
 

--- a/src/process/version.ts
+++ b/src/process/version.ts
@@ -3,7 +3,7 @@ import conventionalRecommendedBump from "conventional-recommended-bump";
 
 import { getLatestGitTagVersion } from "../utils/git-tag-version";
 import { getReleaseType } from "../utils/release-type";
-import type { ForkConfig } from "../config/schema";
+import type { ForkConfig } from "../config/types";
 import type { FileManager, FileState } from "../strategies/file-manager";
 import type { Logger } from "../utils/logger";
 

--- a/src/strategies/file-manager.ts
+++ b/src/strategies/file-manager.ts
@@ -2,7 +2,7 @@ import { JSONPackage } from "./json-package";
 import { PlainText } from "./plain-text";
 import { MSBuildProject } from "./ms-build-project";
 
-import type { ForkConfig } from "../config/schema";
+import type { ForkConfig } from "../config/types";
 import type { Logger } from "../utils/logger";
 
 export interface FileState {

--- a/src/strategies/json-package.ts
+++ b/src/strategies/json-package.ts
@@ -5,7 +5,7 @@ import { detectNewline } from "detect-newline";
 
 import { stringifyPackage } from "../libs/stringify-package";
 import { fileExists } from "../utils/file-state";
-import type { ForkConfig } from "../config/schema";
+import type { ForkConfig } from "../config/types";
 import type { Logger } from "../utils/logger";
 import type { FileState, IFileManager } from "./file-manager";
 

--- a/src/strategies/ms-build-project.ts
+++ b/src/strategies/ms-build-project.ts
@@ -3,7 +3,7 @@ import { readFileSync, writeFileSync } from "node:fs";
 import * as cheerio from "cheerio/lib/slim";
 
 import { fileExists } from "../utils/file-state";
-import type { ForkConfig } from "../config/schema";
+import type { ForkConfig } from "../config/types";
 import type { Logger } from "../utils/logger";
 import type { FileState, IFileManager } from "./file-manager";
 

--- a/src/strategies/plain-text.ts
+++ b/src/strategies/plain-text.ts
@@ -2,7 +2,7 @@ import { resolve } from "node:path";
 import { readFileSync, writeFileSync } from "node:fs";
 
 import { fileExists } from "../utils/file-state";
-import type { ForkConfig } from "../config/schema";
+import type { ForkConfig } from "../config/types";
 import type { Logger } from "../utils/logger";
 import type { FileState, IFileManager } from "./file-manager";
 

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import type { ForkConfig } from "../config/schema";
+import type { ForkConfig } from "../config/types";
 import type { Logger } from "./logger";
 
 export class Git {

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import type { ForkConfig } from "../config/schema";
+import type { ForkConfig } from "../config/types";
 
 export class Logger {
 	disableLogs = false;


### PR DESCRIPTION
This change moves the schema to a javascript file, this allows us to update the schema without having to run a build to transpile typescript.