### PR TITLE
feat: implement new command flow for inspect-* commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,17 @@ You can then add the following entry to your package.json scripts section and us
 
 For example if you use npm you can now use `npm run release` to run Fork-Version.
 
+### Commands
+
+Fork-Version has a number of command modes which will make the program behave differently. The default "command" is the `main` mode, this mode will be used when no other command is defined.
+
+| Command             | Description                                                            |
+| ------------------- | ---------------------------------------------------------------------- |
+| `main`              | Bumps the version, update files, generate changelog, commits, and tag. |
+| `inspect-version`   | Prints the current version and exit.                                   |
+| `inspect-tag`       | Prints the current git tag and exit.                                   |
+| `validate-config`   | Validates the configuration and exit.                                  |
+
 ### Exit Codes
 
 When ran as a cli tool Fork-Version will exit with one of the following exit codes:
@@ -95,6 +106,7 @@ When ran as a cli tool Fork-Version will exit with one of the following exit cod
 | --------- | ---------------------------- |
 | 0         | Success                      |
 | 1         | General Error                |
+| 2         | Unknown Command              |
 | 3         | Config File Validation Error |
 
 ### Command Line Options
@@ -105,17 +117,24 @@ The following help text can be viewed by running the following command: `npx for
 
 ```text
 Usage:
-  $ fork-version [options]
+  $ fork-version [command?] [options?]
 
 Commands:
-  --help                           Show this help message.
-  --version                        Show the current version of Fork-Version.
-  --inspect-version                If set, Fork-Version will print the current project version and exit.
+  main                             Bumps the version, update files, generate changelog, commit, and tag. [Default when no command is provided]
+  inspect-version                  Prints the current version and exits.
+  inspect-tag                      Prints the current git tag and exits.
+  validate-config                  Validates the configuration and exits.
 
-Options:
+General Options:
+  --version                        Show the current version of Fork-Version and exit.
+  --help                           Show this help message and exit.
+
+Location Options:
   --file, -F                       List of the files to be updated. [Default: ["bower.json", "deno.json", "deno.jsonc", "jsr.json", "jsr.jsonc", "manifest.json", "npm-shrinkwrap.json", "package-lock.json", "package.json"]]
   --glob, -G                       Glob pattern to match files to be updated.
   --path, -P                       The path Fork-Version will run from. [Default: process.cwd()]
+
+Options:
   --changelog                      Name of the changelog file. [Default: "CHANGELOG.md"]
   --header                         The header text for the changelog.
   --tag-prefix                     Specify a prefix for the created tag. [Default: "v"]
@@ -155,6 +174,7 @@ Conventional Changelog Overrides:
 Exit Codes:
   0: Success
   1: General Error
+  2: Unknown Command
   3: Config File Validation Error
 
 Examples:
@@ -169,6 +189,9 @@ Examples:
 
   $ fork-version --glob "*/package.json"
     Run fork-version and update all "package.json" files in subdirectories.
+
+  $ fork-version inspect-version
+    Prints the current version and exits.
 ```
 
 <!-- END COMMAND LINE OPTIONS -->
@@ -268,7 +291,7 @@ Alternatively you can define your config using a key in your `package.json` file
 
 | Property                                              | Type             | Default                 | Description                                                                                                         |
 | :---------------------------------------------------- | :--------------- | :---------------------- | :------------------------------------------------------------------------------------------------------------------ |
-| inspectVersion                                        | boolean          | -                       | Print the current version and exits                                                                                 |
+| command                                               | string           | `main`                  | The command to run. Can be one of: main, inspect-version, inspect-tag, validate-config. Defaults to main.           |
 | [files](#configfiles)                                 | Array\<string>   | `["package.json", ...]` | List of the files to be updated                                                                                     |
 | [glob](#configglob)                                   | string           | -                       | Glob pattern to match files to be updated                                                                           |
 | path                                                  | string           | `process.cwd()`         | The path Fork-Version will run from                                                                                 |

--- a/schema/latest.json
+++ b/schema/latest.json
@@ -2,6 +2,16 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "object",
   "properties": {
+    "command": {
+      "description": "The command to run. Can be one of: main, inspect-version, inspect-tag, validate-config. Defaults to main.",
+      "type": "string",
+      "enum": [
+        "main",
+        "inspect-version",
+        "inspect-tag",
+        "validate-config"
+      ]
+    },
     "inspectVersion": {
       "description": "If set, Fork-Version will print the current version and exit.",
       "type": "boolean"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,79 +10,75 @@ import { Logger } from "./services/logger";
 import { FileManager } from "./files/file-manager";
 import { Git } from "./services/git";
 
-import { getCommitsSinceTag } from "./process/get-commits";
-import { getCurrentVersion } from "./process/get-current-version";
-import { getNextVersion } from "./process/get-next-version";
-import { updateChangelog } from "./process/changelog";
-import { commitChanges } from "./process/commit";
-import { tagChanges } from "./process/tag";
+import { validateConfig } from "./commands/validate-config";
+import { inspectVersion } from "./commands/inspect-version";
+import { inspectTag } from "./commands/inspect-tag";
+import { main } from "./commands/main";
 
-async function runFork(cliArguments: ReturnType<typeof getCliArguments>) {
+async function runFork() {
 	const startTime = Date.now();
 
+	const cliArguments = getCliArguments();
 	const config = await getUserConfig(cliArguments);
-
 	const logger = new Logger(config);
 	const fileManager = new FileManager(config, logger);
 	const git = new Git(config);
 
-	logger.log(`Running fork-version - ${new Date().toUTCString()}`);
-	logger.warn(config.dryRun ? "[Dry Run] No changes will be written to disk.\n" : "");
+	switch (config.command) {
+		case "validate-config": {
+			validateConfig(config);
+			break;
+		}
 
-	const commits = await getCommitsSinceTag(config, logger, git);
+		case "inspect-version": {
+			await inspectVersion(config, logger, fileManager, git);
+			break;
+		}
 
-	const current = await getCurrentVersion(config, logger, git, fileManager, config.files);
-	const next = await getNextVersion(config, logger, commits.commits, current.version);
+		case "inspect-tag": {
+			await inspectTag(config, git);
+			break;
+		}
 
-	logger.log("Updating files: ");
-	for (const outFile of current.files) {
-		logger.log(`  - ${outFile.path}`);
+		case "main": {
+			const result = await main(config, logger, fileManager, git);
 
-		fileManager.write(outFile, next.version);
-	}
+			//#region Post-run instructions
+			const branchName = await git.getBranchName();
+			logger.log(
+				`\nRun \`git push --follow-tags origin ${branchName}\` to push the changes and the tag.`,
+			);
 
-	await updateChangelog(config, logger, next.version);
-	await commitChanges(config, logger, git, current.files, next.version);
-	await tagChanges(config, logger, git, next.version);
+			if (result.current.files.some((file) => file.name === "package.json" && !file.isPrivate)) {
+				const npmTag = typeof config.preRelease === "string" ? config.preRelease : "prerelease";
+				logger.log(
+					`${result.next.releaseType}`.startsWith("pre")
+						? `Run \`npm publish --tag ${npmTag}\` to publish the package.`
+						: "Run `npm publish` to publish the package.",
+				);
+			}
+			//#endregion Post-run instructions
 
-	// Print git push command
-	const branchName = await git.getBranchName();
-	logger.log(
-		`\nRun \`git push --follow-tags origin ${branchName}\` to push the changes and the tag.`,
-	);
+			if (!config.dryRun && config.debug) {
+				writeFileSync(
+					join(config.path, `fork-version-${Date.now()}.debug-log.json`),
+					JSON.stringify(result, null, 2),
+				);
+			}
 
-	// Print npm publish command
-	if (current.files.some((file) => file.name === "package.json" && file.isPrivate === false)) {
-		const npmTag = typeof config.preRelease === "string" ? config.preRelease : "prerelease";
-		logger.log(
-			`${next.releaseType}`.startsWith("pre")
-				? `Run \`npm publish --tag ${npmTag}\` to publish the package.`
-				: "Run `npm publish` to publish the package.",
-		);
+			break;
+		}
+
+		default: {
+			console.error(`Unknown command: ${config.command}`);
+			process.exit(2);
+		}
 	}
 
 	logger.debug(`Completed in ${Date.now() - startTime} ms`);
-
-	const result = {
-		config,
-		current,
-		next,
-	};
-
-	if (!config.dryRun && config.debug) {
-		writeFileSync(
-			join(config.path, `fork-version-${Date.now()}.debug-log.json`),
-			JSON.stringify(result, null, 2),
-		);
-	}
-
-	return result;
 }
 
-const cliArguments = getCliArguments();
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-runFork(cliArguments).catch((error: Error | any) => {
+runFork().catch((error) => {
 	if (error instanceof Error) {
 		// If the error is a ZodError, print the keys that failed validation
 		if (error.cause instanceof ZodError) {
@@ -93,11 +89,8 @@ runFork(cliArguments).catch((error: Error | any) => {
 			process.exit(3);
 		}
 
-		if (error.stack) {
-			console.error(error.stack);
-		} else {
-			console.error(error.message);
-		}
+		console.error(error.message);
+		if (error.stack) console.error(error.stack);
 	} else {
 		console.error(error);
 	}

--- a/src/commands/__tests__/inspect-tag.test.ts
+++ b/src/commands/__tests__/inspect-tag.test.ts
@@ -1,0 +1,32 @@
+import { setupTest } from "../../../tests/setup-tests";
+import { inspectTag } from "../inspect-tag";
+
+describe("inspect-tag", () => {
+	it("should log the most recent tag and exit if inspectTag set", async () => {
+		const spyOnConsole = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+		const { config, execGit, git, create } = await setupTest("inspect-tag");
+		config.command = "inspect-tag";
+
+		create.json({ version: "1.2.3" }, "package.json").add();
+		execGit.commit("feat: first commit");
+		execGit.tag("v1.2.3", "feat: first commit");
+
+		await inspectTag(config, git);
+		expect(spyOnConsole).toHaveBeenCalledWith("v1.2.3");
+
+		spyOnConsole.mockRestore();
+	});
+
+	it("should log nothing and exit if no tags found", async () => {
+		const spyOnConsole = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+		const { config, git } = await setupTest("inspect-tag");
+		config.command = "inspect-tag";
+
+		await inspectTag(config, git);
+		expect(spyOnConsole).toHaveBeenCalledWith("");
+
+		spyOnConsole.mockRestore();
+	});
+});

--- a/src/commands/__tests__/inspect-version.test.ts
+++ b/src/commands/__tests__/inspect-version.test.ts
@@ -1,0 +1,52 @@
+import { setupTest } from "../../../tests/setup-tests";
+import { FileManager } from "../../files/file-manager";
+import { inspectVersion } from "../inspect-version";
+
+describe("inspect-version", () => {
+	it("should log the version and exit if inspectVersion set", async () => {
+		const spyOnConsole = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+		const { config, create, execGit, git, logger } = await setupTest("inspect-version");
+		config.command = "inspect-version";
+		const fileManager = new FileManager(config, logger);
+
+		create.json({ version: "1.2.3" }, "package.json").add();
+		execGit.commits();
+
+		await inspectVersion(config, logger, fileManager, git);
+		expect(spyOnConsole).toHaveBeenCalledWith("1.2.3");
+
+		spyOnConsole.mockRestore();
+	});
+
+	it("should log the version from a git tag", async () => {
+		const spyOnConsole = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+		const { config, create, execGit, git, logger } = await setupTest("inspect-version");
+		config.command = "inspect-version";
+		config.gitTagFallback = true; // Defaults to off when running tests.
+		const fileManager = new FileManager(config, logger);
+
+		create.file(`Hello World`, "README.md").add();
+		execGit.commit("feat: first commit");
+		execGit.tag("v2.3.4", "feat: first commit");
+
+		await inspectVersion(config, logger, fileManager, git);
+		expect(spyOnConsole).toHaveBeenCalledWith("2.3.4");
+
+		spyOnConsole.mockRestore();
+	});
+
+	it("should not throw if no version found", async () => {
+		const spyOnConsole = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+		const { config, git, logger } = await setupTest("inspect-version");
+		config.command = "inspect-version";
+		const fileManager = new FileManager(config, logger);
+
+		await inspectVersion(config, logger, fileManager, git);
+		expect(spyOnConsole).toHaveBeenCalledWith("");
+
+		spyOnConsole.mockRestore();
+	});
+});

--- a/src/commands/inspect-tag.ts
+++ b/src/commands/inspect-tag.ts
@@ -1,0 +1,8 @@
+import type { ForkConfig } from "../config/types";
+import type { Git } from "../services/git";
+
+export async function inspectTag(config: ForkConfig, git: Git) {
+	const tag = await git.getMostRecentTag(config.tagPrefix);
+
+	console.log(tag ?? "");
+}

--- a/src/commands/inspect-version.ts
+++ b/src/commands/inspect-version.ts
@@ -1,0 +1,24 @@
+import { getCurrentVersion } from "../process/get-current-version";
+
+import type { ForkConfig } from "../config/types";
+import type { Logger } from "../services/logger";
+import type { FileManager } from "../files/file-manager";
+import type { Git } from "../services/git";
+
+export async function inspectVersion(
+	config: ForkConfig,
+	logger: Logger,
+	fileManager: FileManager,
+	git: Git,
+) {
+	let foundVersion = "";
+
+	try {
+		const currentVersion = await getCurrentVersion(config, logger, git, fileManager, config.files);
+		if (currentVersion) foundVersion = currentVersion.version;
+	} catch {
+		// No version found
+	}
+
+	console.log(foundVersion);
+}

--- a/src/commands/main.ts
+++ b/src/commands/main.ts
@@ -1,0 +1,38 @@
+import { getCommitsSinceTag } from "../process/get-commits";
+import { getCurrentVersion } from "../process/get-current-version";
+import { getNextVersion } from "../process/get-next-version";
+import { updateChangelog } from "../process/changelog";
+import { commitChanges } from "../process/commit";
+import { tagChanges } from "../process/tag";
+
+import type { ForkConfig } from "../config/types";
+import type { Logger } from "../services/logger";
+import type { FileManager } from "../files/file-manager";
+import type { Git } from "../services/git";
+
+export async function main(config: ForkConfig, logger: Logger, fileManager: FileManager, git: Git) {
+	logger.log(`Running fork-version - ${new Date().toUTCString()}`);
+	logger.warn(config.dryRun ? "[Dry Run] No changes will be written to disk.\n" : "");
+
+	const commits = await getCommitsSinceTag(config, logger, git);
+	const current = await getCurrentVersion(config, logger, git, fileManager, config.files);
+	const next = await getNextVersion(config, logger, commits.commits, current.version);
+
+	logger.log("Updating files: ");
+	for (const outFile of current.files) {
+		logger.log(`  - ${outFile.path}`);
+
+		fileManager.write(outFile, next.version);
+	}
+
+	await updateChangelog(config, logger, next.version);
+	await commitChanges(config, logger, git, current.files, next.version);
+	await tagChanges(config, logger, git, next.version);
+
+	return {
+		config,
+		commits,
+		current,
+		next,
+	};
+}

--- a/src/commands/validate-config.ts
+++ b/src/commands/validate-config.ts
@@ -1,0 +1,13 @@
+import type { ForkConfig } from "../config/types";
+
+export function validateConfig(config: ForkConfig): void {
+	// Validation is done during config initialisation, so if we reach this point the config is valid.
+	// The default flow already prints errors, so we just print the valid config here.
+
+	console.log(`
+⚙️ Configuration:
+${JSON.stringify(config, null, 2)}
+
+✅ Configuration is valid.
+`);
+}

--- a/src/commit-parser/__tests__/commit-parser.test.ts
+++ b/src/commit-parser/__tests__/commit-parser.test.ts
@@ -215,7 +215,7 @@ describe("commit-parser", () => {
 		let logger: Logger;
 
 		beforeAll(() => {
-			logger = new Logger({ silent: false, debug: true, inspectVersion: false });
+			logger = new Logger({ silent: false, debug: true });
 		});
 		beforeEach(() => {
 			debugSpy = vi.spyOn(global.console, "debug").mockImplementation(() => undefined);

--- a/src/config/__tests__/load-config.test.ts
+++ b/src/config/__tests__/load-config.test.ts
@@ -11,23 +11,23 @@ describe("load-config", async () => {
 	it("should load fork.config.ts", async () => {
 		const { create, testFolder } = await setupTest("load-config");
 
-		create.file(`export default { inspectVersion: true };`, "fork.config.ts");
+		create.file(`export default { commitAll: true };`, "fork.config.ts");
 
-		await expect(loadConfigFile(testFolder)).resolves.toStrictEqual({ inspectVersion: true });
+		await expect(loadConfigFile(testFolder)).resolves.toStrictEqual({ commitAll: true });
 	});
 
 	it("should load fork.config.cjs", async () => {
 		const { create, testFolder } = await setupTest("load-config");
 
-		create.file(`module.exports = { inspectVersion: true };`, "fork.config.cjs");
+		create.file(`module.exports = { commitAll: true };`, "fork.config.cjs");
 
-		await expect(loadConfigFile(testFolder)).resolves.toStrictEqual({ inspectVersion: true });
+		await expect(loadConfigFile(testFolder)).resolves.toStrictEqual({ commitAll: true });
 	});
 
 	it("should validate fork.config.ts", async () => {
 		const { create, testFolder } = await setupTest("load-config");
 
-		create.file(`export default { inspectVersion: "true" };`, "fork.config.ts");
+		create.file(`export default { commitAll: "true" };`, "fork.config.ts");
 
 		await expect(loadConfigFile(testFolder)).rejects.toThrow(/^Validation error in: /);
 	});
@@ -35,15 +35,15 @@ describe("load-config", async () => {
 	it("should load fork.config.json", async () => {
 		const { create, testFolder } = await setupTest("load-config");
 
-		create.json({ inspectVersion: true }, "fork.config.json");
+		create.json({ commitAll: true }, "fork.config.json");
 
-		await expect(loadConfigFile(testFolder)).resolves.toStrictEqual({ inspectVersion: true });
+		await expect(loadConfigFile(testFolder)).resolves.toStrictEqual({ commitAll: true });
 	});
 
 	it("should validate fork.config.json", async () => {
 		const { create, testFolder } = await setupTest("load-config");
 
-		create.json({ inspectVersion: "true" }, "fork.config.json");
+		create.json({ commitAll: "true" }, "fork.config.json");
 
 		await expect(loadConfigFile(testFolder)).rejects.toThrow(/^Validation error in: /);
 	});
@@ -59,9 +59,9 @@ describe("load-config", async () => {
 	it("should load package.json", async () => {
 		const { create, testFolder } = await setupTest("load-config");
 
-		create.json({ "fork-version": { inspectVersion: true } }, "package.json");
+		create.json({ "fork-version": { commitAll: true } }, "package.json");
 
-		await expect(loadConfigFile(testFolder)).resolves.toStrictEqual({ inspectVersion: true });
+		await expect(loadConfigFile(testFolder)).resolves.toStrictEqual({ commitAll: true });
 	});
 
 	it("should validate package.json", async () => {
@@ -70,7 +70,7 @@ describe("load-config", async () => {
 		create.json(
 			{
 				"fork-version": {
-					inspectVersion: "true",
+					commitAll: "true",
 				},
 			},
 			"package.json",
@@ -82,13 +82,13 @@ describe("load-config", async () => {
 	it("should load config from a parent directory", async () => {
 		const { create, relativeTo } = await setupTest("load-config");
 
-		create.json({ inspectVersion: true }, "fork.config.json");
+		create.json({ commitAll: true }, "fork.config.json");
 		create.directory("sub-folder");
 		create.directory("sub-folder", "sub-folder-2");
 		create.file(`v1.2.3`, "sub-folder", "sub-folder-2", "my-version.txt");
 
 		await expect(loadConfigFile(relativeTo("sub-folder", "sub-folder-2"))).resolves.toStrictEqual({
-			inspectVersion: true,
+			commitAll: true,
 		});
 	});
 

--- a/src/config/__tests__/user-config.test.ts
+++ b/src/config/__tests__/user-config.test.ts
@@ -1,0 +1,79 @@
+import { setupTest } from "../../../tests/setup-tests";
+import { getUserConfig } from "../user-config";
+
+describe("user-config", () => {
+	it("should have the default command set", async () => {
+		const { testFolder } = await setupTest("load-config");
+
+		const config = await getUserConfig({
+			input: [],
+			flags: {
+				path: testFolder,
+			},
+		});
+
+		expect(config).toBeDefined();
+		expect(config.command).toBe("main");
+		expect(config.silent).toBe(false);
+	});
+
+	it("should be able to set the command via cli args", async () => {
+		const { testFolder } = await setupTest("load-config");
+
+		const config = await getUserConfig({
+			input: ["inspect-version"],
+			flags: {
+				path: testFolder,
+			},
+		});
+
+		expect(config).toBeDefined();
+		expect(config.command).toBe("inspect-version");
+		expect(config.silent).toBe(true);
+	});
+
+	it("should be able to set the command via config file", async () => {
+		const { testFolder, create } = await setupTest("user-config");
+
+		create.json({ command: "inspect-version" }, "fork.config.json");
+		const config = await getUserConfig({
+			input: [],
+			flags: {
+				path: testFolder,
+			},
+		});
+
+		expect(config).toBeDefined();
+		expect(config.command).toBe("inspect-version");
+	});
+
+	it("should prefer cli args over config file", async () => {
+		const { testFolder, create } = await setupTest("user-config");
+
+		create.json({ command: "main" }, "fork.config.json");
+		const config = await getUserConfig({
+			input: ["inspect-version"],
+			flags: {
+				path: testFolder,
+			},
+		});
+
+		expect(config).toBeDefined();
+		expect(config.command).toBe("inspect-version");
+	});
+
+	it("should respect deprecated --inspect-version flag", async () => {
+		const { testFolder, create } = await setupTest("user-config");
+
+		create.json({ inspectVersion: true }, "fork.config.json");
+		const config = await getUserConfig({
+			input: ["inspect-tag"],
+			flags: {
+				path: testFolder,
+			},
+		});
+
+		expect(config).toBeDefined();
+		expect(config.command).toBe("inspect-version");
+	});
+});

--- a/src/config/changelog-preset-config.ts
+++ b/src/config/changelog-preset-config.ts
@@ -2,13 +2,12 @@ import { z } from "zod";
 import conventionalChangelogConfigSpec from "conventional-changelog-config-spec";
 
 import { ChangelogPresetConfigTypeSchema, ChangelogPresetConfigSchema } from "./schema";
-import type { ForkConfig } from "./types";
-import type { getCliArguments } from "./cli-arguments";
+import type { ForkVersionCLIArgs, ForkConfig } from "./types";
 import type { DetectedGitHost } from "./detect-git-host";
 
 export function getChangelogPresetConfig(
 	mergedConfig: Partial<ForkConfig> | undefined,
-	cliArguments: Partial<ReturnType<typeof getCliArguments>>,
+	cliArguments: ForkVersionCLIArgs["flags"],
 	detectedGitHost: DetectedGitHost | null,
 ) {
 	const preset: { name: string; [_: string]: unknown } = {

--- a/src/config/cli-arguments.js
+++ b/src/config/cli-arguments.js
@@ -5,17 +5,24 @@ import meow from "meow";
 // without the need for a build step, otherwise it would also be typescript...
 
 export const helperText = `Usage:
-  $ fork-version [options]
+  $ fork-version [command?] [options?]
 
 Commands:
-  --help                           Show this help message.
-  --version                        Show the current version of Fork-Version.
-  --inspect-version                If set, Fork-Version will print the current project version and exit.
+  main                             Bumps the version, update files, generate changelog, commit, and tag. [Default when no command is provided]
+  inspect-version                  Prints the current version and exits.
+  inspect-tag                      Prints the current git tag and exits.
+  validate-config                  Validates the configuration and exits.
 
-Options:
+General Options:
+  --version                        Show the current version of Fork-Version and exit.
+  --help                           Show this help message and exit.
+
+Location Options:
   --file, -F                       List of the files to be updated. [Default: ["bower.json", "deno.json", "deno.jsonc", "jsr.json", "jsr.jsonc", "manifest.json", "npm-shrinkwrap.json", "package-lock.json", "package.json"]]
   --glob, -G                       Glob pattern to match files to be updated.
   --path, -P                       The path Fork-Version will run from. [Default: process.cwd()]
+
+Options:
   --changelog                      Name of the changelog file. [Default: "CHANGELOG.md"]
   --header                         The header text for the changelog.
   --tag-prefix                     Specify a prefix for the created tag. [Default: "v"]
@@ -55,6 +62,7 @@ Conventional Changelog Overrides:
 Exit Codes:
   0: Success
   1: General Error
+  2: Unknown Command
   3: Config File Validation Error
 
 Examples:
@@ -68,7 +76,10 @@ Examples:
     Run fork-version and update the "package.json" and "MyApi.csproj" files.
 
   $ fork-version --glob "*/package.json"
-    Run fork-version and update all "package.json" files in subdirectories.`;
+    Run fork-version and update all "package.json" files in subdirectories.
+
+  $ fork-version inspect-version
+    Prints the current version and exits.`;
 
 export function getCliArguments() {
 	return meow(helperText, {
@@ -77,6 +88,7 @@ export function getCliArguments() {
 		helpIndent: 0,
 		flags: {
 			// Commands
+			/** @deprecated Set the `inspect-version` command instead. */
 			inspectVersion: { type: "boolean" },
 
 			// Options
@@ -117,5 +129,5 @@ export function getCliArguments() {
 			releaseCommitMessageFormat: { type: "string" },
 			releaseMessageSuffix: { type: "string" },
 		},
-	}).flags;
+	});
 }

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -2,7 +2,7 @@ import type { ForkConfig } from "./types";
 
 export const DEFAULT_CONFIG: ForkConfig = {
 	// Commands
-	inspectVersion: false,
+	command: "main",
 
 	// Options
 	files: [

--- a/src/config/schema.js
+++ b/src/config/schema.js
@@ -73,11 +73,29 @@ export const ForkConfigSchema = z.object({
 	//
 
 	/**
+	 * The command to run, can be one of the following:
+	 *
+	 * - `main` - Bumps the version, update files, generate changelog, commit, and tag.
+	 * - `inspect-version` - Prints the current version and exits.
+	 * - `inspect-tag` - Prints the current git tag and exits.
+	 * - `validate-config` - Validates the configuration and exits.
+	 *
+	 * @default "main"
+	 */
+	command: z
+		.literal(["main", "inspect-version", "inspect-tag", "validate-config"])
+		.describe(
+			"The command to run. Can be one of: main, inspect-version, inspect-tag, validate-config. Defaults to main.",
+		),
+	/**
 	 * If set, Fork-Version will print the current version and exit.
 	 * @default false
+	 *
+	 * @deprecated Set the `inspect-version` command instead.
 	 */
 	inspectVersion: z
 		.boolean()
+		.optional()
 		.describe("If set, Fork-Version will print the current version and exit."),
 
 	// Options

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -1,6 +1,14 @@
 import type { z } from "zod";
 import type { ForkConfigSchema } from "./schema";
+import type { getCliArguments } from "./cli-arguments";
 
 export type ForkConfig = z.infer<typeof ForkConfigSchema>;
 
 export type Config = Partial<ForkConfig>;
+
+type CLIArguments = ReturnType<typeof getCliArguments>;
+
+export interface ForkVersionCLIArgs {
+	input: CLIArguments["input"];
+	flags: Partial<CLIArguments["flags"]>;
+}

--- a/src/config/user-config.ts
+++ b/src/config/user-config.ts
@@ -6,20 +6,17 @@ import { DEFAULT_CONFIG } from "./defaults";
 import { detectGitHost } from "./detect-git-host";
 import { loadConfigFile } from "./load-config";
 import { mergeFiles } from "./merge-files";
-import type { getCliArguments } from "./cli-arguments";
-import type { ForkConfig } from "./types";
+import type { ForkVersionCLIArgs, ForkConfig } from "./types";
 
-export async function getUserConfig(
-	cliArguments: Partial<ReturnType<typeof getCliArguments>>,
-): Promise<ForkConfig> {
-	const cwd = cliArguments.path ? resolve(cliArguments.path) : process.cwd();
+export async function getUserConfig(cliArguments: ForkVersionCLIArgs): Promise<ForkConfig> {
+	const cwd = cliArguments.flags.path ? resolve(cliArguments.flags.path) : process.cwd();
 
 	const configFile = await loadConfigFile(cwd);
 
 	const mergedConfig = {
 		...DEFAULT_CONFIG,
 		...configFile,
-		...cliArguments,
+		...cliArguments.flags,
 	} as ForkConfig;
 
 	let globResults: string[] = [];
@@ -31,22 +28,39 @@ export async function getUserConfig(
 		});
 	}
 
-	const files = mergeFiles(configFile?.files, cliArguments?.files, globResults);
+	const files = mergeFiles(configFile?.files, cliArguments.flags.files, globResults);
 	const detectedGitHost = await detectGitHost(cwd);
 	const changelogPresetConfig = getChangelogPresetConfig(
 		mergedConfig,
-		cliArguments,
+		cliArguments.flags,
 		detectedGitHost,
 	);
+
+	let command: ForkConfig["command"] = DEFAULT_CONFIG.command;
+	if (cliArguments.input.length > 0 && cliArguments.input[0].trim()) {
+		command = cliArguments.input[0].trim().toLowerCase() as ForkConfig["command"];
+	} else if (mergedConfig.command.trim()) {
+		command = mergedConfig.command.trim().toLowerCase() as ForkConfig["command"];
+	}
+
+	// Support deprecated `--inspect-version` flag. Will be removed in a future major release.
+	if (mergedConfig.inspectVersion) {
+		command = "inspect-version";
+	}
+
+	// Force silent mode to avoid printing unnecessary information when running other commands.
+	const shouldBeSilent = ![DEFAULT_CONFIG.command].includes(command);
 
 	return {
 		...mergedConfig,
 
+		command,
 		files,
 		path: cwd,
 		preRelease:
 			// Meow doesn't support multiple flags with the same name, so we need to check both.
-			cliArguments.preReleaseTag ?? cliArguments.preRelease ?? configFile.preRelease,
+			cliArguments.flags.preReleaseTag ?? cliArguments.flags.preRelease ?? configFile.preRelease,
+		silent: shouldBeSilent || mergedConfig.silent,
 		changelogPresetConfig,
 	};
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,8 @@
+export { inspectTag } from "./commands/inspect-tag";
+export { inspectVersion } from "./commands/inspect-version";
+export { main } from "./commands/main";
+export { validateConfig } from "./commands/validate-config";
+
 export { CommitParser } from "./commit-parser/commit-parser";
 export { filterRevertedCommits } from "./commit-parser/filter-reverted-commits";
 export { createParserOptions, type ParserOptions } from "./commit-parser/options";

--- a/src/process/__tests__/get-current-version.test.ts
+++ b/src/process/__tests__/get-current-version.test.ts
@@ -168,25 +168,6 @@ describe("getCurrentVersion", () => {
 		});
 	});
 
-	it("should log the version and exit if inspectVersion set", async () => {
-		const spyOnConsole = vi.spyOn(console, "log").mockImplementation(() => undefined);
-		const spyOnProcess = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
-
-		const { config, create, execGit, git, logger } = await setupTest("version getCurrentVersion");
-		config.inspectVersion = true;
-		const fileManager = new FileManager(config, logger);
-
-		create.json({ version: "1.2.3" }, "package.json").add();
-		execGit.commits();
-
-		await getCurrentVersion(config, logger, git, fileManager, config.files);
-		expect(spyOnConsole).toHaveBeenCalledWith("1.2.3");
-		expect(spyOnProcess).toHaveBeenCalledWith(0);
-
-		spyOnConsole.mockRestore();
-		spyOnProcess.mockRestore();
-	});
-
 	it("should ignore git ignored files", async () => {
 		const { config, create, execGit, git, logger, relativeTo } = await setupTest(
 			"version getCurrentVersion",

--- a/src/process/get-current-version.ts
+++ b/src/process/get-current-version.ts
@@ -62,12 +62,6 @@ export async function getCurrentVersion(
 
 	const currentVersion = semver.rsort(Array.from(versions))[0];
 
-	// If we're just inspecting the version, output the version and exit
-	if (config.inspectVersion) {
-		console.log(currentVersion);
-		process.exit(0);
-	}
-
 	logger.log(`Current version: ${currentVersion}`);
 	return {
 		files,

--- a/src/services/__tests__/logger.test.ts
+++ b/src/services/__tests__/logger.test.ts
@@ -18,7 +18,7 @@ describe("logger", () => {
 	});
 
 	it("should log a message", () => {
-		const logger = new Logger({ silent: false, debug: false, inspectVersion: false });
+		const logger = new Logger({ silent: false, debug: false });
 
 		logger.log("log test");
 		logger.warn("warn test");
@@ -32,7 +32,7 @@ describe("logger", () => {
 	});
 
 	it("should not log if silent is true", () => {
-		const logger = new Logger({ silent: true, debug: false, inspectVersion: false });
+		const logger = new Logger({ silent: true, debug: false });
 
 		logger.log("log test");
 		logger.warn("warn test");
@@ -48,7 +48,7 @@ describe("logger", () => {
 	it("should log a debug message if debug is true", () => {
 		const enabledDebugSpy = vi.spyOn(global.console, "debug").mockImplementation(() => undefined);
 
-		const logger = new Logger({ silent: false, debug: true, inspectVersion: false });
+		const logger = new Logger({ silent: false, debug: true });
 		logger.debug("debug test");
 
 		expect(enabledDebugSpy).toHaveBeenCalledWith("debug test");

--- a/src/services/logger.ts
+++ b/src/services/logger.ts
@@ -5,14 +5,14 @@ import type { ForkConfig } from "../config/types";
 export class Logger {
 	disableLogs = false;
 
-	constructor(private config: Pick<ForkConfig, "silent" | "debug" | "inspectVersion">) {
+	constructor(private config: Pick<ForkConfig, "silent" | "debug">) {
 		this.log = this.log.bind(this);
 		this.warn = this.warn.bind(this);
 		this.error = this.error.bind(this);
 		this.debug = this.debug.bind(this);
 
-		// Disable logs if silent or inspectVersion is set
-		this.disableLogs = this.config.silent || this.config.inspectVersion;
+		// Disable logs if silent
+		this.disableLogs = this.config.silent;
 	}
 
 	public log(...messages: any[]) {

--- a/tests/setup-tests.ts
+++ b/tests/setup-tests.ts
@@ -70,7 +70,7 @@ export async function setupTest(testName: string, options?: Partial<ISetupTestOp
 	execSync(`git config user.email "${userEmail}"`, execSyncOptions);
 
 	//#region Create default test config, logger and git instances
-	const config = await getUserConfig({});
+	const config = await getUserConfig({ input: [], flags: {} });
 	config.path = testFolder;
 	config.header = "# Test Header\n";
 	config.changelogPresetConfig = {
@@ -88,7 +88,7 @@ export async function setupTest(testName: string, options?: Partial<ISetupTestOp
 	};
 	config.gitTagFallback = false;
 
-	const logger = new Logger({ silent: true, debug: false, inspectVersion: false });
+	const logger = new Logger({ silent: true, debug: false });
 	logger.log = vi.fn();
 	logger.warn = vi.fn();
 	logger.error = vi.fn();


### PR DESCRIPTION
This change involved moving around some furniture, I've moved the main cli flow out to a new main command. This has allowed me to add some new functional "modes" and expose an already existing mode in a more correct way.

Now when running fork-version the user can ask the program to output the most recent tag:

```sh
npx fork-version inspect-tag
```

The existing `--inspect-version` flag is also exposed like this now and will be removed in the next major release:

```sh
npx fork-version inspect-version
```

A new `validate-config` command was added to print the configuration content fork-version has found and is running with, this should make it easier to debug what values have been selected.

Closes #102