### PR TITLE
refactor: move build metadata out of yaml class

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,6 +472,15 @@ If you are using one of the following Git hosts, Fork-Version will automatically
 - [Install Shield ISM](#install-shield-ism)
 - [Custom File Updater's](#custom-file-updaters)
 
+> [!Note]
+> If your version strings include build metadata like one of the following examples:
+>
+> - 1.2.3+49a3f2b
+> - 1.2.3-0+49a3f2b
+> - 1.2.3-alpha.0+49a3f2b
+>
+> this metadata will be retained without modification.
+
 #### Json Package
 
 A json package is a json file which contains a version property, such as a npm package.json file.
@@ -494,9 +503,6 @@ description: "My project"
 publish_to: 'none'
 version: 1.2.3
 ```
-
-> [!NOTE]
-> If you're using Fork-Version for a flutter project, Fork-Version will split the version and the builder number on the "+" character, the version will be updated and the builder number will be left as is.
 
 #### Plain Text
 

--- a/src/files/__tests__/file-manager.test.ts
+++ b/src/files/__tests__/file-manager.test.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+
 import { readFile, writeFile } from "node:fs/promises";
 import { readFileSync } from "node:fs";
 
@@ -18,7 +20,9 @@ describe("files file-manager", () => {
 			create.json({ version: "1.2.3" }, "package.json");
 
 			const file = await fileManager.read("package.json");
+			expect(file).toBeDefined();
 			expect(file?.version).toBe("1.2.3");
+			expect(file?.buildMetadata).toBeUndefined();
 		});
 
 		it("should write .json", async () => {
@@ -38,6 +42,23 @@ describe("files file-manager", () => {
 			const packageJSON = JSON.parse(readFileSync(relativeTo("package.json"), "utf8"));
 			expect(packageJSON.version).toBe("1.2.3");
 		});
+
+		it("should retain build metadata when writing new version", async () => {
+			const { config, create, logger, relativeTo } = await setupTest("files file-manager");
+			const fileManager = new FileManager(config, logger);
+
+			create.json({ version: "1.2.3+55" }, "package.json");
+
+			const file = await fileManager.read("package.json");
+			expect(file).toBeDefined();
+			expect(file?.version).toBe("1.2.3");
+			expect(file?.buildMetadata).toBe("55");
+
+			await fileManager.write(file!, "1.2.4");
+
+			const packageJSON = JSON.parse(readFileSync(relativeTo("package.json"), "utf8"));
+			expect(packageJSON.version).toBe("1.2.4+55");
+		});
 	});
 
 	describe("yaml file", () => {
@@ -49,7 +70,7 @@ describe("files file-manager", () => {
 				`name: wordionary
 description: "A new Flutter project."
 publish_to: 'none'
-version: 1.2.3+55 # Comment about the version number
+version: 1.2.3 # Comment about the version number
 environment:
   sdk: ^3.5.4
 
@@ -58,11 +79,41 @@ environment:
 			);
 
 			const file = await fileManager.read("pubspec.yaml");
+			expect(file).toBeDefined();
 			expect(file?.version).toBe("1.2.3");
-			expect(file?.builderNumber).toBe("55");
+			expect(file?.buildMetadata).toBeUndefined();
 		});
 
 		it("should write .yaml", async () => {
+			const { config, create, logger, relativeTo } = await setupTest("files file-manager");
+			const fileManager = new FileManager(config, logger);
+
+			create.file(
+				`name: wordionary
+description: "A new Flutter project."
+publish_to: 'none'
+version: 1.2.3 # Comment about the version number
+environment:
+  sdk: ^3.5.4
+`,
+				"pubspec.yaml",
+			);
+
+			await fileManager.write(
+				{
+					path: relativeTo("pubspec.yaml"),
+					version: "1.2.3",
+				},
+				"2.4.6",
+			);
+
+			const file = await fileManager.read(relativeTo("pubspec.yaml"));
+			expect(file).toBeDefined();
+			expect(file?.version).toBe("2.4.6");
+			expect(file?.buildMetadata).toBeUndefined();
+		});
+
+		it("should retain build metadata when writing new version to .yaml", async () => {
 			const { config, create, logger, relativeTo } = await setupTest("files file-manager");
 			const fileManager = new FileManager(config, logger);
 
@@ -77,18 +128,17 @@ environment:
 				"pubspec.yaml",
 			);
 
-			await fileManager.write(
-				{
-					path: relativeTo("pubspec.yaml"),
-					version: "1.2.3",
-					builderNumber: 55,
-				},
-				"2.4.6",
-			);
+			const file = await fileManager.read("pubspec.yaml");
+			expect(file).toBeDefined();
+			expect(file?.version).toBe("1.2.3");
+			expect(file?.buildMetadata).toBe("55");
 
-			const file = await fileManager.read(relativeTo("pubspec.yaml"));
-			expect(file?.version).toBe("2.4.6");
-			expect(file?.builderNumber).toBe("55");
+			await fileManager.write(file!, "2.4.6");
+
+			const updatedFile = await fileManager.read(relativeTo("pubspec.yaml"));
+			expect(updatedFile).toBeDefined();
+			expect(updatedFile?.version).toBe("2.4.6");
+			expect(updatedFile?.buildMetadata).toBe("55");
 		});
 	});
 
@@ -100,7 +150,9 @@ environment:
 			create.file("1.2.3", "version.txt");
 
 			const file = await fileManager.read("version.txt");
+			expect(file).toBeDefined();
 			expect(file?.version).toBe("1.2.3");
+			expect(file?.buildMetadata).toBeUndefined();
 		});
 
 		it("should write version.txt", async () => {
@@ -116,8 +168,28 @@ environment:
 				},
 				"1.2.3",
 			);
+
 			const version = readFileSync(relativeTo("version.txt"), "utf8");
 			expect(version).toBe("1.2.3");
+		});
+
+		it("should retain build metadata when writing new version to version.txt", async () => {
+			const { config, create, logger, relativeTo } = await setupTest("files file-manager");
+			const fileManager = new FileManager(config, logger);
+
+			create.file("1.2.3+55", "version.txt");
+
+			await fileManager.write(
+				{
+					path: relativeTo("version.txt"),
+					version: "1.2.3",
+					buildMetadata: "55",
+				},
+				"1.2.4",
+			);
+
+			const version = readFileSync(relativeTo("version.txt"), "utf8");
+			expect(version).toBe("1.2.4+55");
 		});
 	});
 
@@ -137,7 +209,9 @@ environment:
 			);
 
 			const file = await fileManager.read("API.csproj");
+			expect(file).toBeDefined();
 			expect(file?.version).toBe("1.2.3");
+			expect(file?.buildMetadata).toBeUndefined();
 		});
 
 		it("should write .csproj", async () => {
@@ -248,7 +322,6 @@ environment:
 			const file = await fileManager.read("test.json");
 			expect(file?.version).toBe("1.2.3");
 
-			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 			await fileManager.write(file!, "2.3.4");
 
 			const updatedFile = await fileManager.read("test.json");
@@ -296,7 +369,6 @@ environment:
 			const file = await fileManager.read("test.json");
 			expect(file?.version).toBe("1.2.3");
 
-			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 			await fileManager.write(file!, "2.3.4");
 
 			const updatedFile = await fileManager.read("test.json");

--- a/src/files/__tests__/yaml-package.test.ts
+++ b/src/files/__tests__/yaml-package.test.ts
@@ -20,8 +20,7 @@ environment:
 		);
 
 		const file = await fileManager.read(relativeTo("pubspec.yaml"));
-		expect(file?.version).toBe("1.2.3");
-		expect(file?.builderNumber).toBe("55");
+		expect(file?.version).toBe("1.2.3+55");
 	});
 
 	it("should read a regular yaml file", async () => {
@@ -37,7 +36,6 @@ version: 1.2.3 # Comment about the version number
 
 		const file = await fileManager.read(relativeTo("my-project.yaml"));
 		expect(file?.version).toBe("1.2.3");
-		expect(file?.builderNumber).toBeUndefined();
 	});
 
 	it("should throw an error if unable to read version", async () => {
@@ -78,14 +76,13 @@ environment:
 			{
 				path: relativeTo("pubspec.yaml"),
 				version: "1.2.3",
-				builderNumber: 55,
+				buildMetadata: "55",
 			},
-			"2.4.6",
+			"2.4.6+55",
 		);
 
 		const file = await fileManager.read(relativeTo("pubspec.yaml"));
-		expect(file?.version).toBe("2.4.6");
-		expect(file?.builderNumber).toBe("55");
+		expect(file?.version).toBe("2.4.6+55");
 	});
 
 	it("should write a regular yaml file", async () => {
@@ -103,14 +100,12 @@ version: 1.2.3 # Comment about the version number
 			{
 				path: relativeTo("my-project.yaml"),
 				version: "1.2.3",
-				builderNumber: undefined,
 			},
 			"2.4.6",
 		);
 
 		const file = await fileManager.read(relativeTo("my-project.yaml"));
 		expect(file?.version).toBe("2.4.6");
-		expect(file?.builderNumber).toBeUndefined();
 	});
 
 	it("should match known yaml files", async () => {

--- a/src/files/file-manager.ts
+++ b/src/files/file-manager.ts
@@ -8,6 +8,7 @@ import { MSBuildProject } from "./ms-build-project";
 import { ARMBicep } from "./arm-bicep";
 import { InstallShieldISM } from "./install-shield-ism";
 
+import { extractBuildMetadata } from "../utils/extract-build-metadata";
 import type { ForkConfig } from "../config/types";
 import type { Logger } from "../services/logger";
 
@@ -29,6 +30,7 @@ export class MissingPropertyException extends Error {
 export interface FileState {
 	path: string;
 	version: string;
+	buildMetadata?: string;
 	[other: string]: unknown;
 }
 
@@ -127,7 +129,19 @@ export class FileManager {
 		for (const fileManager of this.#fileManagers) {
 			if (fileManager.isSupportedFile(fileNameLower)) {
 				try {
-					return await fileManager.read(filePath);
+					const fileState = await fileManager.read(filePath);
+
+					if (fileState) {
+						const { version, buildMetadata } = extractBuildMetadata(fileState.version);
+
+						// If the version string contains build metadata, split it out into a separate property.
+						if (buildMetadata) {
+							fileState.version = version;
+							fileState.buildMetadata = buildMetadata;
+						}
+					}
+
+					return fileState;
 				} catch (error) {
 					if (error instanceof MissingPropertyException) {
 						this.#logger.warn(
@@ -166,9 +180,15 @@ export class FileManager {
 		const relativePath = relative(this.#config.path, fileState.path);
 		const fileNameLower = relativePath.toLocaleLowerCase();
 
+		// If the file has build metadata, append it to the new version string before writing to the file.
+		let updatedVersion = newVersion;
+		if (fileState?.buildMetadata) {
+			updatedVersion += `+${fileState.buildMetadata}`;
+		}
+
 		for (const fileManager of this.#fileManagers) {
 			if (fileManager.isSupportedFile(fileNameLower)) {
-				return await fileManager.write(fileState, newVersion);
+				return await fileManager.write(fileState, updatedVersion);
 			}
 		}
 

--- a/src/files/yaml-package.ts
+++ b/src/files/yaml-package.ts
@@ -16,41 +16,14 @@ import { MissingPropertyException, type FileState, type IFileManager } from "./f
  * ```
  */
 export class YAMLPackage implements IFileManager {
-	/**
-	 * If the version is returned with a "+" symbol in the value then the version might be from a
-	 * flutter `pubspec.yaml` file, if so we want to retain the input builderNumber by splitting it
-	 * and joining it again later.
-	 */
-	#handleBuildNumber(fileVersion: string): {
-		version: string;
-		builderNumber?: string;
-	} {
-		const [version, builderNumber] = fileVersion.split("+");
-
-		// If the builderNumber is an integer then we'll return the split value.
-		if (/^\d+$/.test(builderNumber)) {
-			return {
-				version,
-				builderNumber,
-			};
-		}
-
-		return {
-			version: fileVersion,
-		};
-	}
-
 	async read(filePath: string): Promise<FileState | undefined> {
 		const fileContents = await readFile(filePath, "utf8");
 
 		const fileVersion = parse(fileContents)?.version;
 		if (fileVersion) {
-			const parsedVersion = this.#handleBuildNumber(fileVersion);
-
 			return {
 				path: filePath,
-				version: parsedVersion.version || "",
-				builderNumber: parsedVersion.builderNumber ?? undefined,
+				version: fileVersion,
 			};
 		}
 
@@ -61,12 +34,7 @@ export class YAMLPackage implements IFileManager {
 		const fileContents = await readFile(fileState.path, "utf8");
 		const yamlDocument = parseDocument(fileContents);
 
-		let newFileVersion = newVersion;
-		if (fileState.builderNumber !== undefined) {
-			newFileVersion += `+${fileState.builderNumber}`; // Reattach builderNumber if previously set.
-		}
-
-		yamlDocument.set("version", newFileVersion);
+		yamlDocument.set("version", newVersion);
 
 		await writeFile(fileState.path, yamlDocument.toString(), "utf8");
 	}

--- a/src/utils/__tests__/extract-build-metadata.test.ts
+++ b/src/utils/__tests__/extract-build-metadata.test.ts
@@ -1,0 +1,37 @@
+import { extractBuildMetadata } from "../extract-build-metadata";
+
+describe("extract-build-metadata", () => {
+	it("should return undefined if there is no build metadata", () => {
+		expect(extractBuildMetadata("1.2.3")).toEqual({
+			version: "1.2.3",
+			buildMetadata: undefined,
+		});
+		expect(extractBuildMetadata("1.2.3-0")).toEqual({
+			version: "1.2.3-0",
+			buildMetadata: undefined,
+		});
+		expect(extractBuildMetadata("1.2.3-alpha.0")).toEqual({
+			version: "1.2.3-alpha.0",
+			buildMetadata: undefined,
+		});
+		expect(extractBuildMetadata("1.2.3+")).toEqual({
+			version: "1.2.3",
+			buildMetadata: undefined,
+		});
+	});
+
+	it("should extract build metadata from version string", () => {
+		expect(extractBuildMetadata("1.2.3+49a3f2b")).toEqual({
+			version: "1.2.3",
+			buildMetadata: "49a3f2b",
+		});
+		expect(extractBuildMetadata("1.2.3-0+49a3f2b")).toEqual({
+			version: "1.2.3-0",
+			buildMetadata: "49a3f2b",
+		});
+		expect(extractBuildMetadata("1.2.3-alpha.0+49a3f2b")).toEqual({
+			version: "1.2.3-alpha.0",
+			buildMetadata: "49a3f2b",
+		});
+	});
+});

--- a/src/utils/extract-build-metadata.ts
+++ b/src/utils/extract-build-metadata.ts
@@ -1,0 +1,43 @@
+export interface BuildMetadata {
+	version: string;
+	buildMetadata: string | undefined;
+}
+
+/**
+ * This function is used to separate build metadata from the version string.
+ * Build metadata is denoted by a plus sign (`+`) followed by a string of characters.
+ *
+ * Example version strings including build metadata:
+ * - `1.2.3+49a3f2b`
+ * - `1.2.3-0+49a3f2b`
+ * - `1.2.3-alpha.0+49a3f2b`
+ *
+ * In the above examples, the build metadata is `+49a3f2b`, which should be
+ * ignored when determining the next version.
+ *
+ * @param version The version string to extract build metadata from.
+ * @return Both the version string without build metadata and the extracted build metadata (if any).
+ *
+ * @example
+ * ```ts
+ * const versionWithMetadata = "1.2.3+49a3f2b";
+ * const { version, buildMetadata } = extractBuildMetadata(versionWithMetadata);
+ * console.log(version); // Output: "1.2.3"
+ * console.log(buildMetadata); // Output: "49a3f2b"
+ * ```
+ */
+export function extractBuildMetadata(version: string): BuildMetadata {
+	const plusIndex = version.indexOf("+");
+
+	if (plusIndex === -1) {
+		return {
+			version,
+			buildMetadata: undefined,
+		};
+	}
+
+	return {
+		version: version.substring(0, plusIndex),
+		buildMetadata: version.substring(plusIndex + 1) || undefined,
+	};
+}


### PR DESCRIPTION
This change makes it so all file managers extract a build metadata string from a version number and reattach it when writing a file if defined.

Closes #126 